### PR TITLE
When cloning esmf, use full depth

### DIFF
--- a/build-esmf-docs/base/Dockerfile
+++ b/build-esmf-docs/base/Dockerfile
@@ -2,13 +2,22 @@
 # Documentation build dependencies for ESMF #
 #############################################
 
-FROM ubuntu:18.04
+FROM ubuntu:plucky
 
-ENV _DEBIAN_FRONTEND=$DEBIAN_FRONTEND
-# Avoid having to interact with terminal when installing time-related packages
-ENV DEBIAN_FRONTEND=noninteractive
-RUN ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime
-RUN apt-get -y update && apt-get -y install texlive-full latex2html perl csh \
-    git build-essential zip gfortran
-ENV DEBIAN_FRONTEND=$_DEBIAN_FRONTEND
-ENV _DEBIAN_FRONTEND=""
+# install packages
+RUN <<INSTALL_PACKAGES bash
+  apt-get update
+  ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime
+  apt-get install -y tzdata
+  dpkg-reconfigure --frontend noninteractive tzdata
+  apt-get install -y \
+    texlive-full \
+    latex2html \
+    perl \
+    csh \
+    git \
+    build-essential \
+    zip \
+    gfortran
+  apt-get clean
+INSTALL_PACKAGES

--- a/build-esmf-docs/esmf/Dockerfile
+++ b/build-esmf-docs/esmf/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p ${ESMF_ARTIFACTS}
 
 # Clone ESMF
 WORKDIR ${HOME}/sandbox/esmf
-RUN git clone --branch ${ESMF_BRANCH} --depth 1 https://github.com/esmf-org/esmf.git src-git
+RUN git clone --branch ${ESMF_BRANCH} https://github.com/esmf-org/esmf.git src-git
 
 ENV ESMF_DIR=${HOME}/sandbox/esmf/src-git
 

--- a/build-esmf-docs/esmpy/Dockerfile
+++ b/build-esmf-docs/esmpy/Dockerfile
@@ -16,7 +16,7 @@ ENV ARTIFACTS=/artifacts/doc-esmpy
 RUN mkdir -p ${ARTIFACTS}
 
 WORKDIR /opt/
-RUN git clone --branch ${ESMF_BRANCH} --depth 1 https://github.com/esmf-org/esmf.git
+RUN git clone --branch ${ESMF_BRANCH} https://github.com/esmf-org/esmf.git
 
 ENV ESMF_DIR=/opt/esmf
 ENV ESMF_INSTALL_PREFIX=/usr/local

--- a/build-esmf-docs/esmpy/Dockerfile
+++ b/build-esmf-docs/esmpy/Dockerfile
@@ -1,13 +1,22 @@
-FROM ubuntu:focal
+FROM ubuntu:plucky
 
-ENV _DEBIAN_FRONTEND=$DEBIAN_FRONTEND
-# Avoid having to interact with terminal when installing time-related packages
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get --yes update && apt-get --yes install latexmk texlive-fonts-recommended \
-    texlive-latex-recommended texlive-latex-extra build-essential gfortran git \
+# install packages
+RUN <<INSTALL_PACKAGES bash
+  apt-get update
+  ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime
+  apt-get install -y tzdata
+  dpkg-reconfigure --frontend noninteractive tzdata
+  apt-get install -y \
+    latexmk \
+    texlive-fonts-recommended \
+    texlive-latex-recommended \
+    texlive-latex-extra \
+    build-essential \
+    gfortran \
+    git \
     python3-pip
-ENV DEBIAN_FRONTEND=$_DEBIAN_FRONTEND
-ENV _DEBIAN_FRONTEND=""
+  apt-get clean
+INSTALL_PACKAGES
 
 ARG ESMF_BRANCH="develop"
 RUN echo "ESMF_BRANCH=$ESMF_BRANCH"
@@ -31,7 +40,11 @@ RUN make -j 2
 RUN make install
 
 ENV ESMFMKFILE=${ESMF_INSTALL_LIBDIR}/esmf.mk
-RUN pip3 install sphinx sphinxcontrib-packages sphinxcontrib-bibtex
+RUN <<INSTALL_SPHINX bash
+  python3 -m pip config set global.break-system-packages true
+  python3 -m pip install sphinx sphinxcontrib-packages sphinxcontrib-bibtex
+  python3 -m pip config set global.break-system-packages false
+INSTALL_SPHINX
 
 WORKDIR ${ESMF_DIR}/src/addon/esmpy
 RUN python3 -m pip install .

--- a/test-coverage/Dockerfile
+++ b/test-coverage/Dockerfile
@@ -7,7 +7,7 @@ ENV ESMF_ARTIFACTS=/artifacts
 RUN mkdir -p ${ESMF_ARTIFACTS}
 
 WORKDIR ${HOME}/sandbox/esmf
-RUN git clone --branch ${ESMF_BRANCH} --depth 1 https://github.com/esmf-org/esmf.git src-git
+RUN git clone --branch ${ESMF_BRANCH} https://github.com/esmf-org/esmf.git src-git
 
 ENV ESMF_DIR=${HOME}/sandbox/esmf/src-git
 


### PR DESCRIPTION
Using `--depth 1` is problematic when building the ESMPy documentation because (unless the latest commit has been tagged) it means that no tags are available from which the version can be determined. Cloning with full depth only takes a few extra seconds, so do that.

It may be okay to use `--depth 1` for the other clones - for building the ESMF documentation and for test-coverage - but it seems best to keep these consistent, and since the cost is fairly low, this seems safest.