### PR TITLE
Add the *.dvi files to doc artifacts.

### DIFF
--- a/build-esmf-docs/esmf/Dockerfile
+++ b/build-esmf-docs/esmf/Dockerfile
@@ -33,7 +33,7 @@ RUN make
 WORKDIR ${ESMF_DIR}
 RUN cp -rv doc ${ESMF_ARTIFACTS}/doc-esmf
 RUN mkdir ${ESMF_ARTIFACTS}/doc-dvi
-RUN cp -v src/doc/*dvi src/addon/NUOPC/doc/*.dvi ${ESMF_ARTIFACTS}/doc-div
+RUN cp -v src/doc/*.dvi src/addon/NUOPC/doc/*.dvi ${ESMF_ARTIFACTS}/doc-div
 RUN mkdir ${ESMF_ARTIFACTS}/doc-nuopc
 RUN cp -rv src/addon/NUOPC/doc/*.pdf src/addon/NUOPC/doc/NUOPC_refdoc src/addon/NUOPC/doc/NUOPC_howtodoc ${ESMF_ARTIFACTS}/doc-nuopc
 RUN mkdir ${ESMF_ARTIFACTS}/doc-dev_guide

--- a/build-esmf-docs/esmf/Dockerfile
+++ b/build-esmf-docs/esmf/Dockerfile
@@ -32,8 +32,9 @@ RUN make
 # Collect and compress the documentation artifacts
 WORKDIR ${ESMF_DIR}
 RUN cp -rv doc ${ESMF_ARTIFACTS}/doc-esmf
+RUN cp -v src/doc/*dvi ${ESMF_ARTIFACTS}/doc-esmf
 RUN mkdir ${ESMF_ARTIFACTS}/doc-nuopc
-RUN cp -rv src/addon/NUOPC/doc/*.pdf src/addon/NUOPC/doc/NUOPC_refdoc src/addon/NUOPC/doc/NUOPC_howtodoc ${ESMF_ARTIFACTS}/doc-nuopc
+RUN cp -rv src/addon/NUOPC/doc/*.dvi src/addon/NUOPC/doc/*.pdf src/addon/NUOPC/doc/NUOPC_refdoc src/addon/NUOPC/doc/NUOPC_howtodoc ${ESMF_ARTIFACTS}/doc-nuopc
 RUN mkdir ${ESMF_ARTIFACTS}/doc-dev_guide
 RUN cp -rv src/doc/dev_guide ${ESMF_ARTIFACTS}/doc-dev_guide
 

--- a/build-esmf-docs/esmf/Dockerfile
+++ b/build-esmf-docs/esmf/Dockerfile
@@ -32,9 +32,10 @@ RUN make
 # Collect and compress the documentation artifacts
 WORKDIR ${ESMF_DIR}
 RUN cp -rv doc ${ESMF_ARTIFACTS}/doc-esmf
-RUN cp -v src/doc/*dvi ${ESMF_ARTIFACTS}/doc-esmf
+RUN mkdir ${ESMF_ARTIFACTS}/doc-dvi
+RUN cp -v src/doc/*dvi src/addon/NUOPC/doc/*.dvi ${ESMF_ARTIFACTS}/doc-div
 RUN mkdir ${ESMF_ARTIFACTS}/doc-nuopc
-RUN cp -rv src/addon/NUOPC/doc/*.dvi src/addon/NUOPC/doc/*.pdf src/addon/NUOPC/doc/NUOPC_refdoc src/addon/NUOPC/doc/NUOPC_howtodoc ${ESMF_ARTIFACTS}/doc-nuopc
+RUN cp -rv src/addon/NUOPC/doc/*.pdf src/addon/NUOPC/doc/NUOPC_refdoc src/addon/NUOPC/doc/NUOPC_howtodoc ${ESMF_ARTIFACTS}/doc-nuopc
 RUN mkdir ${ESMF_ARTIFACTS}/doc-dev_guide
 RUN cp -rv src/doc/dev_guide ${ESMF_ARTIFACTS}/doc-dev_guide
 


### PR DESCRIPTION
Help determine whether doc issues with new docker image show on DVI level, or later.