### PR TITLE
Use esmf/build-esmf-docs-base with ubuntu-18.04

### DIFF
--- a/build-esmf-docs/esmf/Dockerfile
+++ b/build-esmf-docs/esmf/Dockerfile
@@ -2,7 +2,7 @@
 # Build and collect ESMF documentation #
 ########################################
 
-FROM esmf/build-esmf-docs-base
+FROM esmf/build-esmf-docs-base:2022-07-28
 
 ARG ESMF_BRANCH="develop"
 RUN echo "ESMF_BRANCH=$ESMF_BRANCH"


### PR DESCRIPTION
If you want the older ubuntu-18.04 with the older versions of texlive and latex2html then merge this PR.