### PR TITLE
Upgrade OS and stack for build-esmf-docs/esmf

### DIFF
--- a/build-esmf-docs/esmf/Dockerfile
+++ b/build-esmf-docs/esmf/Dockerfile
@@ -2,7 +2,7 @@
 # Build and collect ESMF documentation #
 ########################################
 
-FROM esmf/build-esmf-docs-base:2022-07-28
+FROM esmf/build-esmf-docs-base:ubuntu-25.04
 
 ARG ESMF_BRANCH="develop"
 RUN echo "ESMF_BRANCH=$ESMF_BRANCH"


### PR DESCRIPTION
Ready to merge once testing with Docker Hub image passes
esmf/build-esmf-docs-base:ubuntu-25.04